### PR TITLE
Compiler compatibility fix

### DIFF
--- a/src/gui/src/Gui_ColourWheel.cpp
+++ b/src/gui/src/Gui_ColourWheel.cpp
@@ -53,7 +53,7 @@ void Gui_ColourWheel::redraw(){
             float aa = (float) mean_hue *  MY_PI /180;
             float bb = (float) m_centr_hue *  MY_PI /180;
 
-            int diff = abs(atan2(sin(aa-bb), cos(aa-bb)) * 180 / MY_PI);
+            int diff = (int) fabs(atan2(sin(aa-bb), cos(aa-bb)) * 180 / MY_PI);
             if(val < m_min_sat || val > m_max_sat || diff > m_tol_hue){
                 chanels[1].at<uchar>(i, j) = 0;
                 chanels[2].at<uchar>(i, j) = 0;

--- a/src/processor/src/Step_FiltHS.cpp
+++ b/src/processor/src/Step_FiltHS.cpp
@@ -46,7 +46,7 @@ std::vector<bool> Step_FiltHS::filter(const Result& in_numerical_result){
 
         float aa = (float) mean_hue *  3.1416 /180;
         float bb = (float) m_centr_hue *  3.1416 /180;
-        int diff = abs(atan2(sin(aa-bb), cos(aa-bb)) * 180 / 3.1416);
+        int diff = (int) fabs(atan2(sin(aa-bb), cos(aa-bb)) * 180 / 3.1416);
         int mean_sat = (int) mean[2];
 
         if(diff > m_tol_hue || mean_sat > m_max_sat || mean_sat < m_min_sat)


### PR DESCRIPTION
Fixed two invalid usages of abs function, giving
"error: call of overloaded ‘abs(double)’ is ambiguous",
on current version of compilers.

Solution tested with g++ 6.2.1 and clang++ 3.8.1.
I tried to keep casting convention.