### PR TITLE
Fix build on OpenCV v4+

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -26,8 +26,8 @@ AC_OPENMP
 
 AC_SUBST(OPENMP_CFLAGS)
 
-# We check for opencv 2.4. if absent, stop!!
-PKG_CHECK_MODULES([OPENCV],[opencv >= 2.4.2],[],[AC_MSG_ERROR(OpenCV not found. Have you installed the library (devel version)). OpenCFU cannot be built without OpenCV!])
+# We check for opencv 3.0.0. if absent, stop!!
+PKG_CHECK_MODULES([OPENCV],[opencv >= 3.0.0],[],[AC_MSG_ERROR(OpenCV not found. Have you installed the library (devel version)). OpenCFU cannot be built without OpenCV!])
 
 ### We add opencv to global AM flags.
 

--- a/src/classifier/main.cpp
+++ b/src/classifier/main.cpp
@@ -89,7 +89,7 @@ int main(int argc, char **argv){
 
 
         cv::Mat sum_cols, sum_mat;
-        cv::reduce(m_mat, sum_cols, 0, CV_REDUCE_SUM);
+        cv::reduce(m_mat, sum_cols, 0, cv::REDUCE_SUM);
         cv::repeat(sum_cols, 3, 1, sum_mat);
         m_mat = (100*m_mat)/sum_mat;
 

--- a/src/gui/headers/Gui_MaskSetter.hpp
+++ b/src/gui/headers/Gui_MaskSetter.hpp
@@ -153,7 +153,7 @@ public:
                 }
                 else{
                     DEV_INFOS("ok mask");
-                    cv::cvtColor(mask_img,tmp_img,CV_GRAY2RGB);
+                    cv::cvtColor(mask_img,tmp_img,cv::COLOR_GRAY2RGB);
                     DEV_INFOS("RGB mask");
                     return true;
                 }

--- a/src/gui/headers/Gui_ProcessorHandler.hpp
+++ b/src/gui/headers/Gui_ProcessorHandler.hpp
@@ -37,7 +37,7 @@ class Gui_ProcessorHandler
         }
         else{
             DEV_INFOS("getting RGB : OK");
-            cv::cvtColor(m_opts.getImage(),out,CV_BGR2RGB);
+            cv::cvtColor(m_opts.getImage(),out,cv::COLOR_BGR2RGB);
             return true;
         }
     }
@@ -50,7 +50,7 @@ class Gui_ProcessorHandler
             return false;
         }
         else{
-            cv::cvtColor(mat,out,CV_GRAY2RGB);
+            cv::cvtColor(mat,out,cv::COLOR_GRAY2RGB);
             return true;
         }
     }

--- a/src/gui/src/Gui_ColourWheel.cpp
+++ b/src/gui/src/Gui_ColourWheel.cpp
@@ -28,7 +28,7 @@ void Gui_ColourWheel::redraw(){
     const float pixbuf_h = allocation.get_height();
     int siz = std::min(pixbuf_w,pixbuf_h);
     m_img_to_display = cv::Mat(siz*2+1,siz*2+1,CV_8UC3,cv::Scalar(128,128,128));
-    cv::cvtColor(m_img_to_display,m_img_to_display,CV_BGR2HLS);
+    cv::cvtColor(m_img_to_display,m_img_to_display,cv::COLOR_BGR2HLS);
 
     std::vector<cv::Mat> chanels;
     cv::split(m_img_to_display, chanels);
@@ -63,10 +63,10 @@ void Gui_ColourWheel::redraw(){
     }
 
     cv::merge(chanels,m_img_to_display);
-    cv::cvtColor(m_img_to_display,m_img_to_display,CV_HLS2BGR);
+    cv::cvtColor(m_img_to_display,m_img_to_display,cv::COLOR_HLS2BGR);
 //    cv::GaussianBlur(m_img_to_display,m_img_to_display,cv::Size(3,3),1.5);
     cv::resize(m_img_to_display,m_img_to_display,cv::Size(siz,siz),0,0,cv::INTER_NEAREST);
-    cv::cvtColor(m_img_to_display,m_img_to_display,CV_BGR2RGB);
+    cv::cvtColor(m_img_to_display,m_img_to_display,cv::COLOR_BGR2RGB);
 
     h = m_img_to_display.rows;
     w = m_img_to_display.cols;

--- a/src/processor/headers/MaskROI.hpp
+++ b/src/processor/headers/MaskROI.hpp
@@ -13,7 +13,7 @@ class MaskROI
         }
 
         MaskROI(const std::string& path){
-            cv::imread(path,CV_LOAD_IMAGE_GRAYSCALE).copyTo(m_original_mat);
+            cv::imread(path,cv::IMREAD_GRAYSCALE).copyTo(m_original_mat);
             type = MASK_TYPE_FILE;
         }
         MaskROI(cv::Mat img){

--- a/src/processor/headers/ProcessingOptions.hpp
+++ b/src/processor/headers/ProcessingOptions.hpp
@@ -111,7 +111,7 @@ class ProcessingOptions
  * \param str the name of the file to read the image from
  */
         bool setImage(const std::string str){
-            cv::Mat tmpImg = cv::imread(str, CV_LOAD_IMAGE_ANYDEPTH | CV_LOAD_IMAGE_COLOR);
+            cv::Mat tmpImg = cv::imread(str, cv::IMREAD_ANYDEPTH | cv::IMREAD_COLOR);
 
             //patch for 16bit depth imgs:
             if(tmpImg.depth() == CV_16U){

--- a/src/processor/src/ContourSpliter.cpp
+++ b/src/processor/src/ContourSpliter.cpp
@@ -54,7 +54,7 @@ void ContourSpliter::makeWatershedLabel(const cv::Mat& binary, const cont_chunk&
 
 void ContourSpliter::findPeaks(const cv::Mat& binary, cv::Mat& distance_map, cont_chunk& peaks_conts){
     cv::Mat tmp_mat,peaks;
-    cv::distanceTransform(binary,distance_map,CV_DIST_L2,CV_DIST_MASK_5);
+    cv::distanceTransform(binary,distance_map,cv::DIST_L2,cv::DIST_MASK_5);
     cv::dilate(distance_map,peaks,cv::Mat(),cv::Point(-1,-1),3);
     cv::dilate(binary,tmp_mat,cv::Mat(),cv::Point(-1,-1),3);
     peaks = peaks - distance_map;
@@ -62,7 +62,7 @@ void ContourSpliter::findPeaks(const cv::Mat& binary, cv::Mat& distance_map, con
     peaks.convertTo(peaks,CV_8U);
     cv::bitwise_xor(peaks,tmp_mat,peaks);
     cv::dilate(peaks,peaks,cv::Mat(),cv::Point(-1,-1),1);
-    cv::findContours(peaks, peaks_conts, CV_RETR_CCOMP, CV_CHAIN_APPROX_SIMPLE);
+    cv::findContours(peaks, peaks_conts, cv::RETR_CCOMP, cv::CHAIN_APPROX_SIMPLE);
     distance_map.convertTo(distance_map,CV_8U);
 }
 

--- a/src/processor/src/MaskROI.cpp
+++ b/src/processor/src/MaskROI.cpp
@@ -22,7 +22,7 @@ void MaskROI::setFromPoints(const std::vector< std::pair<std::vector<cv::Point2f
             assert((i.first).size() == 3);
             std::vector<float> vec(3);
             vec = circleFrom3(i.first);
-            cv::circle( m_original_mat,cv::Point(vec[0],vec[1]), vec[2], cv::Scalar(j++), CV_FILLED, 8, 0 );
+            cv::circle( m_original_mat,cv::Point(vec[0],vec[1]), vec[2], cv::Scalar(j++), cv::FILLED, 8, 0 );
         }
         else if(i.second == MASK_TOOL_CONV_POLYGON){
             assert((i.first).size() >2 );
@@ -38,13 +38,13 @@ void MaskROI::setFromPoints(const std::vector< std::pair<std::vector<cv::Point2f
 
 void MaskROI::makeAutoMask(const cv::Mat& parent){
     cv::Mat grey;
-    cv::cvtColor(parent,grey,CV_BGR2GRAY);
+    cv::cvtColor(parent,grey,cv::COLOR_BGR2GRAY);
     cv::Mat mask(grey.size(),CV_8UC1,cv::Scalar(0));
 	float r = 256.0/ (float) grey.cols ;
 	cv::resize(grey,grey,cv::Size(0,0),r,r,cv::INTER_AREA);
 	cv::medianBlur(grey,grey,7);
 	std::vector<cv::Vec3f> out;
-	cv::HoughCircles(grey, out,  CV_HOUGH_GRADIENT,2, 100, 150, 10, 75, 350);
+	cv::HoughCircles(grey, out,  cv::HOUGH_GRADIENT,2, 100, 150, 10, 75, 350);
 	if(out.size()>0){
         auto& i = out[0];
         cv::circle(mask,cv::Point(i[0]/r,i[1]/r),i[2]/r,cv::Scalar(1),-1);

--- a/src/processor/src/Result.cpp
+++ b/src/processor/src/Result.cpp
@@ -30,14 +30,14 @@ OneObjectRow::OneObjectRow(ContourFamily cont_fam,const cv::Mat& raw_img):
         cv::Mat one_pix(1,1,CV_8UC3,m_BGR_mean);
         cv::Mat one_pix_hls, one_pix_lab;           //modified NJL 11/AUG/2014
 
-        cv::cvtColor(one_pix,one_pix_hls,CV_BGR2HLS);
+        cv::cvtColor(one_pix,one_pix_hls,cv::COLOR_BGR2HLS);
         cv::Scalar mean_sc = cv::mean(one_pix_hls); //?
 
         m_hue_mean =((int) mean_sc [0])*2;
         m_sat_mean = (int) mean_sc [2];
 
         //added NJL 11/AUG/2014
-        cv::cvtColor(one_pix, one_pix_lab, CV_BGR2Lab);
+        cv::cvtColor(one_pix, one_pix_lab, cv::COLOR_BGR2Lab);
         m_LAB_mean = cv::mean(one_pix_lab);
 
 
@@ -257,7 +257,7 @@ void Result::ColorProcessing(bool ordering){
         cv::Scalar pixelColour((int) it->second[0], (int) it->second[1], (int) it->second[2]);
         cv::Mat onepixBGR;
         cv::Mat onepixLAB(1,1,CV_8UC3,pixelColour);
-        cv::cvtColor(onepixLAB, onepixBGR, CV_Lab2BGR);
+        cv::cvtColor(onepixLAB, onepixBGR, cv::COLOR_Lab2BGR);
         cv::Scalar meanBGR = cv::mean(onepixBGR);
 
         translationTable.emplace(it->first, std::make_pair(currentClusterNumber++, meanBGR));

--- a/src/processor/src/Step_2.cpp
+++ b/src/processor/src/Step_2.cpp
@@ -68,7 +68,7 @@ void Step_2::SubstractLapOGauss(const cv::Mat& in, cv::Mat& out, int blurSize){
     std::vector<cv::Vec4i > hierarchy;
     cv::Mat tmp;
     cv::threshold(tmp_mat,tmp, 10, 255, cv::THRESH_BINARY);
-    cv::findContours(tmp, contours,hierarchy, CV_RETR_CCOMP, CV_CHAIN_APPROX_SIMPLE);//TC89_L1);
+    cv::findContours(tmp, contours,hierarchy, cv::RETR_CCOMP, cv::CHAIN_APPROX_SIMPLE);//TC89_L1);
     for(unsigned int k=0; k<contours.size();k++){
         /* if the contour has no holes and if it is not a hole*/
         if( hierarchy[k][2] < 0 && hierarchy[k][3] < 0){

--- a/src/processor/src/Step_4.cpp
+++ b/src/processor/src/Step_4.cpp
@@ -123,7 +123,7 @@ void Step_4::makeContourChunksVect(const cv::Mat& src,std::vector<ContourFamily>
     if(m_has_auto_thr)
         cv::threshold(src,tmp_mat,m_threshold,255,cv::THRESH_BINARY|cv::THRESH_OTSU);
     else
-        cv::threshold(src,tmp_mat,m_threshold,255,CV_THRESH_BINARY);
+        cv::threshold(src,tmp_mat,m_threshold,255,cv::THRESH_BINARY);
 
 
 

--- a/src/processor/src/Step_BaseClass.cpp
+++ b/src/processor/src/Step_BaseClass.cpp
@@ -43,7 +43,7 @@ bool Step_BaseClass::isSameImage(const cv::Mat& img1,const cv::Mat& img2){
     cv::Mat tmp_mat;
     cv::compare(img1, img2,tmp_mat,cv::CMP_NE);
     if (tmp_mat.channels() == 3)
-        cv::cvtColor(tmp_mat,tmp_mat,CV_BGR2GRAY);
+        cv::cvtColor(tmp_mat,tmp_mat,cv::COLOR_BGR2GRAY);
     int n = cv::countNonZero(tmp_mat);
     if(n > 0){
         DEV_INFOS("Diff Img: different pixels");

--- a/src/processor/src/Step_FiltHS.cpp
+++ b/src/processor/src/Step_FiltHS.cpp
@@ -39,7 +39,7 @@ std::vector<bool> Step_FiltHS::filter(const Result& in_numerical_result){
         const OneObjectRow& oor = in_numerical_result.getRow(i);
         cv::Scalar mean = oor.getBGRMean();
         cv::Mat one_pix(1,1,CV_8UC3,mean);
-        cv::cvtColor(one_pix,one_pix,CV_BGR2HLS);
+        cv::cvtColor(one_pix,one_pix,cv::COLOR_BGR2HLS);
         mean = cv::mean(one_pix);
 
         int mean_hue =((int) mean[0])*2;


### PR DESCRIPTION
OpenCV v4 removes various #defines, so alternative enums and enum classes used instead: e.g. ``CV_LOAD_IMAGE_GRAYSCALE`` becomes ``cv::IMREAD_GRAYSCALE``.

This will also work on OpenCV v3, but not the v2 series. Accordingly, I've also bumped the minimum required version of OpenCV to 3.0.0, which shouldn't be an issue as OpenCV has been out for a really long time now (e.g. it's in Debian stable).